### PR TITLE
Revert "Fixing issue #4, where the absence of a folder would crash the program"

### DIFF
--- a/sensibility/miner/corpus.py
+++ b/sensibility/miner/corpus.py
@@ -121,8 +121,6 @@ class Corpus:
                 if path is None:
                     path = get_sqlite3_path() if path is None else path
                 url = f"sqlite:///{os.fspath(path)}"
-            if not os.path.exists(os.path.dirname(path)):
-                os.makedirs(os.path.dirname(path))
             self.engine = create_engine(url)
 
         self._initialize_sqlite3(writable)


### PR DESCRIPTION
Reverts naturalness/sensibility#5

@luizperes Had to revert this, because it also breaks type-checking. Please look into the `pathlib` library, and run `mypy` before pushing fixes to the code.

Once again, I appreciate the pull requests!